### PR TITLE
create diy.min.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,10 @@
   <body>
   <div class="container">
     <h1>diy.js</h1>
-    <p>A modern cross-platform JavaScript library &amp; only 18 bytes</p>
-    <small>...or just 10 bytes <a href="js/diy.min.js">minified</a></small>
+    <p>
+      A modern cross-platform JavaScript library &amp; only 18 bytes
+      <small>...or just 10 bytes <a href="js/diy.min.js">minified</a></small>
+    </p>
 
     <a href="js/diy.js" class="button button--large">Download Now</a>
 

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
   <div class="container">
     <h1>diy.js</h1>
     <p>A modern cross-platform JavaScript library &amp; only 18 bytes</p>
+    <small>...or just 10 bytes <a href="js/diy.min.js">minified</a></small>
 
     <a href="js/diy.js" class="button button--large">Download Now</a>
 

--- a/js/dig.min.js
+++ b/js/dig.min.js
@@ -1,0 +1,1 @@
+$=document


### PR DESCRIPTION
- removed needless whitespace
- removed needless semicolon
- removed needless `var`

Whitespace is not required before and after `=`.

From the ECMAScript [specs about Rules of Automatic Semicolon Insertion](http://ecma-international.org/ecma-262/5.1/#sec-7.9.1):

> When, as the program is parsed from left to right, the end of the input stream of tokens is encountered and the parser is unable to parse the input token stream as a single complete ECMAScript Program, then a semicolon is automatically inserted at the end of the input stream.

We don't need the `var` keyword because we're not in a function and it is defined in the global space no matter what.

This PR compacts this awesome framework to 10 bytes!
